### PR TITLE
metadata note

### DIFF
--- a/docs/data-sources/Emigration-by-country-1981-2022.md
+++ b/docs/data-sources/Emigration-by-country-1981-2022.md
@@ -18,6 +18,8 @@ tags:
 
 # Emigration by Country (1981-2022)
 
+*Note: To view the full metadata for this data source, please see the raw file in our [GitHub repository](https://github.com/dataengineeringpilipinas/datahub/tree/main/data-sources).*
+
 ## Description
 The dataset contains annual counts of emigrants from the Philippines, broken down by their destination countries. The data spans multiple years from 1981-2022 and includes a variety of destination countries, allowing for the analysis of emigration trends over time.
 

--- a/docs/projects/emigrant-country-dashboard.md
+++ b/docs/projects/emigrant-country-dashboard.md
@@ -16,6 +16,8 @@ alignment: "This project aligns with DEP Data Hub's objective of enabling data e
 
 # Emigrant Country Dashboard
 
+*Note: To view the full metadata for this project, please see the raw file in our [GitHub repository](https://github.com/dataengineeringpilipinas/datahub/tree/main/projects).*
+
 ## Summary
 The Emigrant Country Dashboard project aims to visualize and analyze the emigration trends from the Philippines to various countries from 1981 to 2022. This dashboard provides insights into the patterns and changes in emigration over the years, allowing users to explore the data interactively.
 


### PR DESCRIPTION
because yaml front matter is used for metadata tags, it's not rendering in pages, thus the need for the metadata note